### PR TITLE
Run emulation in a separate process(lynxb)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,6 +68,7 @@
             android:configChanges="orientation|screenSize|uiMode"
             android:exported="true"
             android:launchMode="singleTask"
+            android:process=":emulationProcess"
             android:parentActivityName=".MainActivity">
 
             <intent-filter>

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -219,7 +219,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
                     shouldFinish = false
                     if (returnToMain)
                         startActivity(Intent(applicationContext, MainActivity::class.java).setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP))
-                    finishAffinity()
+                    Process.killProcess(Process.myPid())
                 }
             }
         }


### PR DESCRIPTION
Exiting from emulation has always been a big issue for Skyline, with guest and host threads that would keep running in the background unless the app was manually killed. Running emulation in a separate process allows us to kill it when we are done, avoiding the need for complex exiting management code.